### PR TITLE
Implement self execute transactions

### DIFF
--- a/contracts/modules/commons/interfaces/IModuleCalls.sol
+++ b/contracts/modules/commons/interfaces/IModuleCalls.sol
@@ -43,4 +43,13 @@ interface IModuleCalls {
     uint256 _nonce,
     bytes calldata _signature
   ) external;
+
+  /**
+   * @notice Allow wallet to execute an action
+   *   without signing the message
+   * @param _txs  Transactions to execute
+   */
+  function selfExecute(
+    Transaction[] calldata _txs
+  ) external;
 }

--- a/typings/contracts/IModuleCalls.d.ts
+++ b/typings/contracts/IModuleCalls.d.ts
@@ -32,6 +32,19 @@ interface IModuleCallsInterface extends Interface {
         Arrayish
       ]): string;
     }>;
+
+    selfExecute: TypedFunctionDescription<{
+      encode([_txs]: [
+        {
+          delegateCall: boolean;
+          revertOnError: boolean;
+          gasLimit: BigNumberish;
+          target: string;
+          value: BigNumberish;
+          data: Arrayish;
+        }[]
+      ]): string;
+    }>;
   };
 
   events: {
@@ -79,6 +92,18 @@ export class IModuleCalls extends Contract {
       _signature: Arrayish,
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
+
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[],
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
   };
 
   nonce(): Promise<BigNumber>;
@@ -96,6 +121,18 @@ export class IModuleCalls extends Contract {
     }[],
     _nonce: BigNumberish,
     _signature: Arrayish,
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
+  selfExecute(
+    _txs: {
+      delegateCall: boolean;
+      revertOnError: boolean;
+      gasLimit: BigNumberish;
+      target: string;
+      value: BigNumberish;
+      data: Arrayish;
+    }[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -121,6 +158,17 @@ export class IModuleCalls extends Contract {
       }[],
       _nonce: BigNumberish,
       _signature: Arrayish
+    ): Promise<BigNumber>;
+
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[]
     ): Promise<BigNumber>;
   };
 }

--- a/typings/contracts/MainModule.d.ts
+++ b/typings/contracts/MainModule.d.ts
@@ -81,6 +81,19 @@ interface MainModuleInterface extends Interface {
       encode([_signature]: [Arrayish]): string;
     }>;
 
+    selfExecute: TypedFunctionDescription<{
+      encode([_txs]: [
+        {
+          delegateCall: boolean;
+          revertOnError: boolean;
+          gasLimit: BigNumberish;
+          target: string;
+          value: BigNumberish;
+          data: Arrayish;
+        }[]
+      ]): string;
+    }>;
+
     updateImplementation: TypedFunctionDescription<{
       encode([_implementation]: [string]): string;
     }>;
@@ -187,6 +200,18 @@ export class MainModule extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[],
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     updateImplementation(
       _implementation: string,
       overrides?: TransactionOverrides
@@ -263,6 +288,18 @@ export class MainModule extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
+  selfExecute(
+    _txs: {
+      delegateCall: boolean;
+      revertOnError: boolean;
+      gasLimit: BigNumberish;
+      target: string;
+      value: BigNumberish;
+      data: Arrayish;
+    }[],
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
   updateImplementation(
     _implementation: string,
     overrides?: TransactionOverrides
@@ -335,6 +372,17 @@ export class MainModule extends Contract {
     readNonce(_space: BigNumberish): Promise<BigNumber>;
 
     removeHook(_signature: Arrayish): Promise<BigNumber>;
+
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[]
+    ): Promise<BigNumber>;
 
     updateImplementation(_implementation: string): Promise<BigNumber>;
 

--- a/typings/contracts/MainModuleUpgradable.d.ts
+++ b/typings/contracts/MainModuleUpgradable.d.ts
@@ -79,6 +79,19 @@ interface MainModuleUpgradableInterface extends Interface {
       encode([_signature]: [Arrayish]): string;
     }>;
 
+    selfExecute: TypedFunctionDescription<{
+      encode([_txs]: [
+        {
+          delegateCall: boolean;
+          revertOnError: boolean;
+          gasLimit: BigNumberish;
+          target: string;
+          value: BigNumberish;
+          data: Arrayish;
+        }[]
+      ]): string;
+    }>;
+
     updateImageHash: TypedFunctionDescription<{
       encode([_imageHash]: [Arrayish]): string;
     }>;
@@ -190,6 +203,18 @@ export class MainModuleUpgradable extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[],
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     updateImageHash(
       _imageHash: Arrayish,
       overrides?: TransactionOverrides
@@ -269,6 +294,18 @@ export class MainModuleUpgradable extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
+  selfExecute(
+    _txs: {
+      delegateCall: boolean;
+      revertOnError: boolean;
+      gasLimit: BigNumberish;
+      target: string;
+      value: BigNumberish;
+      data: Arrayish;
+    }[],
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
   updateImageHash(
     _imageHash: Arrayish,
     overrides?: TransactionOverrides
@@ -344,6 +381,17 @@ export class MainModuleUpgradable extends Contract {
     readNonce(_space: BigNumberish): Promise<BigNumber>;
 
     removeHook(_signature: Arrayish): Promise<BigNumber>;
+
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[]
+    ): Promise<BigNumber>;
 
     updateImageHash(_imageHash: Arrayish): Promise<BigNumber>;
 

--- a/typings/contracts/ModuleCalls.d.ts
+++ b/typings/contracts/ModuleCalls.d.ts
@@ -33,6 +33,19 @@ interface ModuleCallsInterface extends Interface {
       ]): string;
     }>;
 
+    selfExecute: TypedFunctionDescription<{
+      encode([_txs]: [
+        {
+          delegateCall: boolean;
+          revertOnError: boolean;
+          gasLimit: BigNumberish;
+          target: string;
+          value: BigNumberish;
+          data: Arrayish;
+        }[]
+      ]): string;
+    }>;
+
     supportsInterface: TypedFunctionDescription<{
       encode([_interfaceID]: [Arrayish]): string;
     }>;
@@ -81,6 +94,18 @@ export class ModuleCalls extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[],
+      overrides?: TransactionOverrides
+    ): Promise<ContractTransaction>;
+
     supportsInterface(_interfaceID: Arrayish): Promise<boolean>;
   };
 
@@ -99,6 +124,18 @@ export class ModuleCalls extends Contract {
     }[],
     _nonce: BigNumberish,
     _signature: Arrayish,
+    overrides?: TransactionOverrides
+  ): Promise<ContractTransaction>;
+
+  selfExecute(
+    _txs: {
+      delegateCall: boolean;
+      revertOnError: boolean;
+      gasLimit: BigNumberish;
+      target: string;
+      value: BigNumberish;
+      data: Arrayish;
+    }[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -126,6 +163,17 @@ export class ModuleCalls extends Contract {
       }[],
       _nonce: BigNumberish,
       _signature: Arrayish
+    ): Promise<BigNumber>;
+
+    selfExecute(
+      _txs: {
+        delegateCall: boolean;
+        revertOnError: boolean;
+        gasLimit: BigNumberish;
+        target: string;
+        value: BigNumberish;
+        data: Arrayish;
+      }[]
     ): Promise<BigNumber>;
 
     supportsInterface(_interfaceID: Arrayish): Promise<BigNumber>;


### PR DESCRIPTION
Allows to wallet to execute transactions without a signature, this can be useful for creating `atomicity bubbles` inside transaction batches.

TODO: Tests