### PR TITLE
Remove addressOf from factory

### DIFF
--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -7,21 +7,4 @@ contract Factory {
     bytes memory code = abi.encodePacked(Wallet.creationCode, uint256(_mainModule));
     assembly { _contract := create2(callvalue(), add(code, 32), mload(code), _salt) }
   }
-
-  function addressOf(address _mainModule, bytes32 _salt) external view returns (address) {
-    bytes memory code = abi.encodePacked(Wallet.creationCode, uint256(_mainModule));
-
-    return address(
-      uint256(
-        keccak256(
-          abi.encodePacked(
-            bytes1(0xff),
-            address(this),
-            _salt,
-            keccak256(code)
-          )
-        )
-      )
-    );
-  }
 }

--- a/src/tests/ERC165.spec.ts
+++ b/src/tests/ERC165.spec.ts
@@ -1,5 +1,5 @@
 import * as ethers from 'ethers'
-import { expect, encodeImageHash, signAndExecuteMetaTx, interfaceIdOf } from './utils'
+import { expect, encodeImageHash, signAndExecuteMetaTx, interfaceIdOf, addressOf } from './utils'
 
 import { MainModule } from 'typings/contracts/MainModule'
 import { MainModuleUpgradable } from 'typings/contracts/MainModuleUpgradable'
@@ -57,7 +57,7 @@ contract('ERC165', () => {
     owner = new ethers.Wallet(ethers.utils.randomBytes(32))
     const salt = encodeImageHash(1, [{ weight: 1, address: owner.address }])
     await factory.deploy(module.address, salt)
-    wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+    wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
   })
 
   describe('Implement all interfaces for ERC165 on MainModule', () => {

--- a/src/tests/Factory.spec.ts
+++ b/src/tests/Factory.spec.ts
@@ -1,5 +1,5 @@
 import * as ethers from 'ethers'
-import { expect } from './utils';
+import { expect, addressOf } from './utils';
 
 import { ModuleMock } from 'typings/contracts/ModuleMock'
 import { Factory } from 'typings/contracts/Factory'
@@ -25,13 +25,15 @@ contract('Factory', (accounts: string[]) => {
       await factory.deploy(module.address, accounts[0])
     })
     it('Should predict wallet address', async () => {
-      const predict = await factory.addressOf(module.address, accounts[0])
-      await factory.deploy(module.address, accounts[0])
+      const hash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+      const predict = addressOf(factory.address, module.address, hash)
+      await factory.deploy(module.address, hash)
       expect(await web3.eth.getCode(predict)).to.not.equal("0x")
     })
     it('Should initialize with main module', async () => {
-      await factory.deploy(module.address, accounts[0])
-      const address = await factory.addressOf(module.address, accounts[0])
+      const hash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+      await factory.deploy(module.address, hash)
+      const address = addressOf(factory.address, module.address, hash)
       const wallet = await ModuleMockArtifact.at(address) as ModuleMock
       expect(((await wallet.ping()) as any).logs[0].event).to.equal("Pong")
     })

--- a/src/tests/MainModule.bench.ts
+++ b/src/tests/MainModule.bench.ts
@@ -1,5 +1,5 @@
 import * as ethers from 'ethers'
-import { signAndExecuteMetaTx, encodeImageHash, multiSignAndExecuteMetaTx } from './utils';
+import { signAndExecuteMetaTx, encodeImageHash, multiSignAndExecuteMetaTx, addressOf } from './utils';
 
 import { MainModule } from 'typings/contracts/MainModule'
 import { Factory } from 'typings/contracts/Factory'
@@ -71,7 +71,7 @@ contract('MainModule', () => {
           const owner = new ethers.Wallet(ethers.utils.randomBytes(32))
           const salt = encodeImageHash(1, [{ weight: 1, address: owner.address }])
           await factory.deploy(module.address, salt)
-          const wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+          const wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
 
           const tx = await signAndExecuteMetaTx(wallet, owner, [transaction], networkId) as any
           results.push(tx.receipt.gasUsed)
@@ -98,7 +98,7 @@ contract('MainModule', () => {
             const owner = new ethers.Wallet(ethers.utils.randomBytes(32))
             const salt = encodeImageHash(1, [{ weight: 1, address: owner.address }])
             await factory.deploy(module.address, salt)
-            const wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+            const wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
 
             const tx = await signAndExecuteMetaTx(wallet, owner, transactions, networkId) as any
             results.push(tx.receipt.gasUsed)
@@ -133,7 +133,7 @@ contract('MainModule', () => {
             const owner = new ethers.Wallet(ethers.utils.randomBytes(32))
             const salt = encodeImageHash(1, [{ weight: 1, address: owner.address }])
             await factory.deploy(module.address, salt)
-            const wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+            const wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
 
             const tx = await signAndExecuteMetaTx(wallet, owner, transactions, networkId) as any
             results.push(tx.receipt.gasUsed)
@@ -169,7 +169,7 @@ contract('MainModule', () => {
           )
 
           await factory.deploy(module.address, salt)
-          const wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+          const wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
 
           const signers = [0, 3]
 
@@ -210,7 +210,7 @@ contract('MainModule', () => {
           )
 
           await factory.deploy(module.address, salt)
-          const wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+          const wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
 
           const accounts = owners.map((owner) => ({
             weight: weight,

--- a/src/tests/MainModule.spec.ts
+++ b/src/tests/MainModule.spec.ts
@@ -1,5 +1,5 @@
 import * as ethers from 'ethers'
-import { expect, signAndExecuteMetaTx, RevertError, ethSign, encodeImageHash, walletSign, walletMultiSign, multiSignAndExecuteMetaTx, encodeNonce, moduleStorageKey, encodeMetaTransactionsData } from './utils';
+import { expect, signAndExecuteMetaTx, RevertError, ethSign, encodeImageHash, walletSign, walletMultiSign, multiSignAndExecuteMetaTx, encodeNonce, moduleStorageKey, encodeMetaTransactionsData, addressOf } from './utils';
 
 import { MainModule } from 'typings/contracts/MainModule'
 import { MainModuleUpgradable } from 'typings/contracts/MainModuleUpgradable'
@@ -52,7 +52,7 @@ contract('MainModule', (accounts: string[]) => {
     owner = new ethers.Wallet(ethers.utils.randomBytes(32))
     const salt = encodeImageHash(1, [{ weight: 1, address: owner.address }])
     await factory.deploy(module.address, salt)
-    wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+    wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
   })
 
   describe('Authentication', () => {
@@ -1062,7 +1062,7 @@ contract('MainModule', (accounts: string[]) => {
         )
 
         await factory.deploy(module.address, salt)
-        wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+        wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
       })
       it('Should accept signed message by first owner', async () => {
         const accounts = [{
@@ -1146,7 +1146,7 @@ contract('MainModule', (accounts: string[]) => {
         )
 
         await factory.deploy(module.address, salt)
-        wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+        wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
       })
       it('Should accept signed message by both owners', async () => {
         const accounts = [{
@@ -1238,7 +1238,7 @@ contract('MainModule', (accounts: string[]) => {
         )
 
         await factory.deploy(module.address, salt)
-        wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+        wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
       })
 
       it('Should accept signed message by first and second owner', async () => {
@@ -1406,7 +1406,7 @@ contract('MainModule', (accounts: string[]) => {
         )
 
         await factory.deploy(module.address, salt)
-        wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+        wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
       })
 
       it('Should accept message signed by all owners', async () => {
@@ -1458,7 +1458,7 @@ contract('MainModule', (accounts: string[]) => {
         )
 
         await factory.deploy(module.address, salt)
-        wallet = await MainModuleArtifact.at(await factory.addressOf(module.address, salt)) as MainModule
+        wallet = await MainModuleArtifact.at(addressOf(factory.address, module.address, salt)) as MainModule
       })
 
       it('Should accept signed message with (3+1)/4 weight', async () => {

--- a/src/tests/utils/helpers.ts
+++ b/src/tests/utils/helpers.ts
@@ -319,3 +319,26 @@ export function interfaceIdOf(int: ethers.utils.Interface): string {
   return signatures.reduce((p, c) => xor(p, c))
 }
 
+export const WALLET_CODE ='0x603a600e3d39601a805130553df3363d3d373d3d3d363d30545af43d82803e903d91601857fd5bf3'
+
+export function addressOf(
+  factory: string,
+  mainModule: string,
+  imageHash: string
+): string {
+  const codeHash = ethers.utils.keccak256(
+    ethers.utils.solidityPack(
+      ['bytes', 'bytes32'],
+      [WALLET_CODE, ethers.utils.hexZeroPad(mainModule, 32)]
+    )
+  )
+
+  const hash = ethers.utils.keccak256(
+    ethers.utils.solidityPack(
+      ['bytes1', 'address', 'bytes32', 'bytes32'],
+      ['0xff', factory, imageHash, codeHash]
+    )
+  )
+
+  return ethers.utils.getAddress(ethers.utils.hexDataSlice(hash, 12))
+}

--- a/typings/contracts/Factory.d.ts
+++ b/typings/contracts/Factory.d.ts
@@ -15,10 +15,6 @@ interface FactoryInterface extends Interface {
     deploy: TypedFunctionDescription<{
       encode([_mainModule, _salt]: [string, Arrayish]): string;
     }>;
-
-    addressOf: TypedFunctionDescription<{
-      encode([_mainModule, _salt]: [string, Arrayish]): string;
-    }>;
   };
 
   events: {};
@@ -43,8 +39,6 @@ export class Factory extends Contract {
       _salt: Arrayish,
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
-
-    addressOf(_mainModule: string, _salt: Arrayish): Promise<string>;
   };
 
   deploy(
@@ -53,13 +47,9 @@ export class Factory extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  addressOf(_mainModule: string, _salt: Arrayish): Promise<string>;
-
   filters: {};
 
   estimate: {
     deploy(_mainModule: string, _salt: Arrayish): Promise<BigNumber>;
-
-    addressOf(_mainModule: string, _salt: Arrayish): Promise<BigNumber>;
   };
 }


### PR DESCRIPTION
The factory + wallet contracts are the hard core of the project, those contracts aren't upgradable and in my opinion we should keep them as simple as possible, `addressOf` can be computed off-chain and there is no need for it to be on the factory contract.