### PR TITLE
Add explicit end of signature

### DIFF
--- a/contracts/modules/commons/ModuleAuth.sol
+++ b/contracts/modules/commons/ModuleAuth.sol
@@ -15,6 +15,7 @@ abstract contract ModuleAuth is IModuleAuth, ModuleERC165, SignatureValidator, I
 
   uint256 private constant FLAG_SIGNATURE = 0;
   uint256 private constant FLAG_ADDRESS = 1;
+  uint256 private constant FLAG_END = 255;
 
   bytes4 private constant SELECTOR_ERC1271_BYTES_BYTES = 0x20c13b0b;
   bytes4 private constant SELECTOR_ERC1271_BYTES32_BYTES = 0x1626ba7e;
@@ -61,8 +62,11 @@ abstract contract ModuleAuth is IModuleAuth, ModuleERC165, SignatureValidator, I
     // Acumulated weight of signatures
     uint256 totalWeight;
 
+    // Boundary of reading index
+    uint256 signatureEnd = _signature.length - 1;
+
     // Iterate until the image is completed
-    while (rindex < _signature.length) {
+    while (rindex < signatureEnd) {
       // Read next item type and addrWeight
       uint256 flag; uint256 addrWeight; address addr;
       (flag, addrWeight, rindex) = _signature.readUint8Uint8(rindex);
@@ -78,6 +82,8 @@ abstract contract ModuleAuth is IModuleAuth, ModuleERC165, SignatureValidator, I
 
         // Acumulate total weight of the signature
         totalWeight += addrWeight;
+      } else if (flag == FLAG_END){
+        break;
       } else {
         revert("ModuleAuth#_signatureValidation INVALID_FLAG");
       }

--- a/src/tests/MainModule.spec.ts
+++ b/src/tests/MainModule.spec.ts
@@ -829,6 +829,31 @@ contract('MainModule', (accounts: string[]) => {
         )
         await expect(tx).to.be.rejectedWith("HookCallerMock#callERC1271isValidSignatureHash: INVALID_RETURN")
       })
+      it('Should ignore tail of signature', async () => {
+        const signature = await walletSign(owner, message) + 'ff1248d23192351011'
+        await hookMock.callERC1271isValidSignatureHash(
+          wallet.address,
+          hash,
+          signature
+        )
+      })
+      it('Should read signature end flag at the end of signature', async () => {
+        const signature = await walletSign(owner, message) + 'ff'
+        await hookMock.callERC1271isValidSignatureHash(
+          wallet.address,
+          hash,
+          signature
+        )
+      })
+      it('Should read tail of signature if stop flag is not present', async () => {
+        const signature = await walletSign(owner, message) + '1248d23192351011'
+        const tx = hookMock.callERC1271isValidSignatureHash(
+          wallet.address,
+          hash,
+          signature
+        )
+        await expect(tx).to.be.rejectedWith("ModuleAuth#_signatureValidation INVALID_FLAG")
+      })
     })
     describe('External hooks', () => {
       let hookMock


### PR DESCRIPTION
Cons:
- Introduces signature malleability, suffixes can be added to signatures and they would still be valid.

Pros:
- Allows using `isValidSignature` by ERC2126 without stripping the suffix.
- Allows relaying transactions with the suffix (ERC1271), while still allowing the relayer to send transactions without suffix to save gas.

Alternative:
- Make all Sequence clients "suffix aware", so the suffix is always stripped prior to signature validation / transaction relay.