### PR TITLE
Allow ignoring gas limit

### DIFF
--- a/contracts/modules/GuestModule.sol
+++ b/contracts/modules/GuestModule.sol
@@ -79,7 +79,7 @@ contract GuestModule is
       // solhint-disable
       (success, result) = transaction.target.call{
         value: transaction.value,
-        gas: transaction.gasLimit
+        gas: transaction.gasLimit == 0 ? gasleft() : transaction.gasLimit
       }(transaction.data);
       // solhint-enable
 

--- a/contracts/modules/commons/ModuleCalls.sol
+++ b/contracts/modules/commons/ModuleCalls.sol
@@ -45,6 +45,9 @@ abstract contract ModuleCalls is IModuleCalls, IModuleAuth, ModuleERC165, Module
 
   /**
    * @notice Allow wallet owner to execute an action
+   * @dev Relayers must ensure that the gasLimit specified for each transaction
+   *      is acceptable to them. A user could specify large enough that it could
+   *      consume all the gas available.
    * @param _txs        Transactions to process
    * @param _nonce      Signature nonce (may contain an encoded space)
    * @param _signature  Encoded signature

--- a/contracts/modules/commons/ModuleCalls.sol
+++ b/contracts/modules/commons/ModuleCalls.sol
@@ -101,6 +101,8 @@ abstract contract ModuleCalls is IModuleCalls, IModuleAuth, ModuleERC165, Module
       bool success;
       bytes memory result;
 
+      require(gasleft() >= transaction.gasLimit, "ModuleCalls#_execute: NOT_ENOUGH_GAS");
+
       if (transaction.delegateCall) {
         (success, result) = transaction.target.delegatecall{
           gas: transaction.gasLimit

--- a/contracts/modules/commons/ModuleCalls.sol
+++ b/contracts/modules/commons/ModuleCalls.sol
@@ -105,12 +105,12 @@ abstract contract ModuleCalls is IModuleCalls, IModuleAuth, ModuleERC165, Module
 
       if (transaction.delegateCall) {
         (success, result) = transaction.target.delegatecall{
-          gas: transaction.gasLimit
+          gas: transaction.gasLimit == 0 ? gasleft() : transaction.gasLimit
         }(transaction.data);
       } else {
         (success, result) = transaction.target.call{
           value: transaction.value,
-          gas: transaction.gasLimit
+          gas: transaction.gasLimit == 0 ? gasleft() : transaction.gasLimit
         }(transaction.data);
       }
 

--- a/src/tests/ERC165.spec.ts
+++ b/src/tests/ERC165.spec.ts
@@ -82,7 +82,7 @@ contract('ERC165', () => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: ethers.constants.Two.pow(21),
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.updateImplementation(moduleUpgradable.address).encodeABI()
@@ -90,7 +90,7 @@ contract('ERC165', () => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: ethers.constants.Two.pow(21),
           target: wallet.address,
           value: ethers.constants.Zero,
           data: newWallet.contract.methods.updateImageHash(newImageHash).encodeABI()

--- a/src/tests/Expirable.spec.ts
+++ b/src/tests/Expirable.spec.ts
@@ -19,6 +19,8 @@ function now(): number {
   return Math.floor(Date.now() / 1000)
 }
 
+const optimalGasLimit = ethers.constants.Two.pow(21)
+
 contract('Expirable', (accounts: string[]) => {
   let factory: Factory
   let module: MainModule
@@ -64,14 +66,14 @@ contract('Expirable', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: expirableUtil.address,
         value: ethers.constants.Zero,
         data: expirableUtil.contract.methods.requireNonExpired(now() + 240).encodeABI()
       }, {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: callReceiver.contract.methods.testCall(valA, valB).encodeABI()
@@ -90,14 +92,14 @@ contract('Expirable', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: expirableUtil.address,
         value: ethers.constants.Zero,
         data: expirableUtil.contract.methods.requireNonExpired(now() - 1).encodeABI()
       }, {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: callReceiver.contract.methods.testCall(valA, valB).encodeABI()

--- a/src/tests/MainModule.bench.ts
+++ b/src/tests/MainModule.bench.ts
@@ -12,7 +12,7 @@ const MainModuleArtifact = artifacts.require('MainModule')
 const runs = 256
 const web3 = (global as any).web3
 
-const optimalGasLimit = ethers.constants.Two.pow(255)
+const optimalGasLimit = ethers.constants.Two.pow(22)
 
 function report(test: string, values: number[]) {
   const min = Math.min(...values)

--- a/src/tests/MainModule.spec.ts
+++ b/src/tests/MainModule.spec.ts
@@ -27,6 +27,8 @@ const GasBurnerMockArtifact = artifacts.require('GasBurnerMock')
 
 const web3 = (global as any).web3
 
+const optimalGasLimit = ethers.constants.Two.pow(21)
+
 contract('MainModule', (accounts: string[]) => {
   let factory
   let module
@@ -60,7 +62,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: ethers.constants.AddressZero,
         value: ethers.constants.Zero,
         data: []
@@ -74,7 +76,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: ethers.constants.AddressZero,
         value: ethers.constants.Zero,
         data: []
@@ -88,7 +90,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: ethers.constants.AddressZero,
           value: ethers.constants.Zero,
           data: []
@@ -110,7 +112,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: ethers.constants.AddressZero,
         value: ethers.constants.Zero,
         data: []
@@ -268,7 +270,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: ethers.constants.AddressZero,
         value: ethers.constants.Zero,
         data: []
@@ -285,7 +287,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.updateImplementation(newImplementation.address).encodeABI()
@@ -300,7 +302,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.updateImplementation(ethers.constants.AddressZero).encodeABI()
@@ -313,7 +315,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.updateImplementation(accounts[1]).encodeABI()
@@ -328,7 +330,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.updateImplementation(newImplementation.address).encodeABI()
@@ -350,7 +352,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: callReceiver.contract.methods.testCall(valA, valB).encodeABI()
@@ -367,7 +369,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: callReceiver.contract.methods.testCall(0, []).encodeABI()
@@ -390,14 +392,14 @@ contract('MainModule', (accounts: string[]) => {
         const transactions = [{
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: callReceiver1.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(val1A, val1B).encodeABI()
         },{
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: callReceiver2.address,
           value: ethers.constants.Zero,
           data: callReceiver2.contract.methods.testCall(val2A, val2B).encodeABI()
@@ -421,14 +423,14 @@ contract('MainModule', (accounts: string[]) => {
         const transactions = [{
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: callReceiver.address,
           value: ethers.constants.Zero,
           data: callReceiver.contract.methods.testCall(valA, valB).encodeABI()
         }, {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: receiver.address,
           value: 26,
           data: []
@@ -449,14 +451,14 @@ contract('MainModule', (accounts: string[]) => {
         const transactions = [{
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: receiver.address,
           value: 26,
           data: []
         }, {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: callReceiver.address,
           value: ethers.constants.Zero,
           data: callReceiver.contract.methods.testCall(0, []).encodeABI()
@@ -476,7 +478,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction1 = {
         delegateCall: true,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: module.address,
         value: 0,
         data: module.contract.methods.write(11, 45).encodeABI()
@@ -487,7 +489,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction2 = {
         delegateCall: true,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: module.address,
         value: 0,
         data: module.contract.methods.read(11).encodeABI()
@@ -502,7 +504,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: true,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: module.address,
           value: 0,
           data: module.contract.methods.setRevertFlag(true).encodeABI()
@@ -514,7 +516,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: true,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: module.address,
           value: 0,
           data: module.contract.methods.write(11, 45).encodeABI()
@@ -526,7 +528,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: true,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: module.address,
           value: 0,
           data: module.contract.methods.write(11, 45).encodeABI()
@@ -549,7 +551,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: receiver.address,
         value: 25,
         data: []
@@ -570,7 +572,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: value,
         data: callReceiver.contract.methods.testCall(valA, valB).encodeABI()
@@ -592,7 +594,7 @@ contract('MainModule', (accounts: string[]) => {
       const transaction = {
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: data
@@ -622,14 +624,14 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver1.address,
         value: ethers.constants.Zero,
         data: data1
       }, {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver2.address,
         value: ethers.constants.Zero,
         data: data2
@@ -660,21 +662,21 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver1.address,
         value: ethers.constants.Zero,
         data: data1
       }, {
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver1.address,
         value: ethers.constants.Zero,
         data: data1
       }, {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver2.address,
         value: ethers.constants.Zero,
         data: data2
@@ -716,14 +718,14 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: data
       }, {
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: data
@@ -747,7 +749,7 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.updateImplementation(ethers.constants.AddressZero).encodeABI()
@@ -840,7 +842,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.addHook(selector, hookMock.address).encodeABI()
@@ -859,7 +861,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.addHook(selector, hookMock.address).encodeABI()
@@ -875,7 +877,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction1 = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.addHook(selector, hookMock.address).encodeABI()
@@ -886,7 +888,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction2 = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.removeHook(selector).encodeABI()
@@ -911,7 +913,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.addHook(selector, hookMock.address).encodeABI()
@@ -927,7 +929,7 @@ contract('MainModule', (accounts: string[]) => {
     const transaction = {
       delegateCall: false,
       revertOnError: true,
-      gasLimit: ethers.constants.MaxUint256,
+      gasLimit: optimalGasLimit,
       target: ethers.constants.AddressZero,
       value: 0,
       data: []
@@ -947,7 +949,7 @@ contract('MainModule', (accounts: string[]) => {
           {
             delegateCall: false,
             revertOnError: true,
-            gasLimit: ethers.constants.MaxUint256,
+            gasLimit: ethers.constants.Two.pow(18),
             target: wallet.address,
             value: ethers.constants.Zero,
             data: wallet.contract.methods.updateImplementation(moduleUpgradable.address).encodeABI()
@@ -955,7 +957,7 @@ contract('MainModule', (accounts: string[]) => {
           {
             delegateCall: false,
             revertOnError: true,
-            gasLimit: ethers.constants.MaxUint256,
+            gasLimit: ethers.constants.Two.pow(18),
             target: wallet.address,
             value: ethers.constants.Zero,
             data: newWallet.contract.methods.updateImageHash(newImageHash).encodeABI()
@@ -966,7 +968,7 @@ contract('MainModule', (accounts: string[]) => {
           {
             delegateCall: false,
             revertOnError: false,
-            gasLimit: ethers.constants.MaxUint256,
+            gasLimit: optimalGasLimit,
             target: wallet.address,
             value: ethers.constants.Zero,
             data: wallet.contract.methods.selfExecute(migrateBundle).encodeABI()
@@ -990,7 +992,7 @@ contract('MainModule', (accounts: string[]) => {
         const transaction = {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.updateImageHash("0x").encodeABI()
@@ -1026,7 +1028,7 @@ contract('MainModule', (accounts: string[]) => {
           const migrateTransactions = [{
             delegateCall: false,
             revertOnError: true,
-            gasLimit: ethers.constants.MaxUint256,
+            gasLimit: optimalGasLimit,
             target: wallet.address,
             value: ethers.constants.Zero,
             data: wallet.contract.methods.updateImageHash(newImageHash).encodeABI()
@@ -1063,7 +1065,7 @@ contract('MainModule', (accounts: string[]) => {
     const transaction = {
       delegateCall: false,
       revertOnError: true,
-      gasLimit: ethers.constants.MaxUint256,
+      gasLimit: optimalGasLimit,
       target: ethers.constants.AddressZero,
       value: 0,
       data: []
@@ -1702,7 +1704,7 @@ contract('MainModule', (accounts: string[]) => {
       }, {
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: callReceiver.address,
         value: ethers.constants.Zero,
         data: callReceiver.contract.methods.testCall(valA, valB).encodeABI()
@@ -1722,7 +1724,7 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.createContract(deployCode).encodeABI()
@@ -1747,7 +1749,7 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = [{
         delegateCall: false,
         revertOnError: false,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: 99,
         data: wallet.contract.methods.createContract(deployCode).encodeABI()
@@ -1769,7 +1771,7 @@ contract('MainModule', (accounts: string[]) => {
     const transaction = {
       delegateCall: false,
       revertOnError: true,
-      gasLimit: ethers.constants.MaxUint256,
+      gasLimit: optimalGasLimit,
       target: ethers.constants.AddressZero,
       value: ethers.constants.Zero,
       data: []
@@ -1798,7 +1800,7 @@ contract('MainModule', (accounts: string[]) => {
       expect(log2.data).to.be.equal(txHash)
     })
   })
-  describe('Interanl bundles', () => {
+  describe('Internal bundles', () => {
     it('Should execute internal bundle', async () => {
       const callReceiver1 = await CallReceiverMockArtifact.new() as CallReceiverMock
       const callReceiver2 = await CallReceiverMockArtifact.new() as CallReceiverMock
@@ -1810,7 +1812,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit.div(ethers.constants.Two),
           target: callReceiver1.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(11, expected1).encodeABI()
@@ -1818,7 +1820,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit.div(ethers.constants.Two),
           target: callReceiver2.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(12, expected2).encodeABI()
@@ -1829,7 +1831,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.selfExecute(bundle).encodeABI()
@@ -1867,7 +1869,7 @@ contract('MainModule', (accounts: string[]) => {
         return bundle.map((obj) => ({
           delegateCall: false,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit.div(ethers.constants.Two),
           value: ethers.constants.Zero,
           target: (contracts[obj.i] as CallReceiverMock).address,
           data: (contracts[obj.i] as CallReceiverMock).contract.methods.testCall(obj.a, expectedb[obj.i]).encodeABI()
@@ -1877,7 +1879,7 @@ contract('MainModule', (accounts: string[]) => {
       const transactions = bundles.map((bundle) => ({
         delegateCall: false,
         revertOnError: true,
-        gasLimit: ethers.constants.MaxUint256,
+        gasLimit: optimalGasLimit,
         target: wallet.address,
         value: ethers.constants.Zero,
         data: wallet.contract.methods.selfExecute(bundle).encodeABI()
@@ -1902,7 +1904,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit.div(4),
           target: callReceiver1.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(11, expected1).encodeABI()
@@ -1910,7 +1912,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit.div(4),
           target: callReceiver2.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(12, expected2).encodeABI()
@@ -1921,7 +1923,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit.div(2),
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.selfExecute(bundle).encodeABI()
@@ -1932,7 +1934,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.selfExecute(nestedBundle).encodeABI()
@@ -1954,13 +1956,13 @@ contract('MainModule', (accounts: string[]) => {
 
       const expected1 = await web3.utils.randomHex(552)
       const expected2 = await web3.utils.randomHex(24)
-      const expected3 = await web3.utils.randomHex(5123)
+      const expected3 = await web3.utils.randomHex(11)
 
       const bundle = [
         {
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: ethers.utils.bigNumberify(100000),
           target: callReceiver1.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(11, expected1).encodeABI()
@@ -1968,17 +1970,17 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: ethers.utils.bigNumberify(100000),
           target: callReceiver2.address,
           value: ethers.constants.Zero,
           data: callReceiver2.contract.methods.testCall(12, expected2).encodeABI()
         },
         {
-          // Tris transaction will revert
+          // This transaction will revert
           // because Factory has no fallback
           delegateCall: false,
           revertOnError: true,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: ethers.utils.bigNumberify(100000),
           target: factory.address,
           value: ethers.constants.Zero,
           data: callReceiver1.contract.methods.testCall(12, expected2).encodeABI()
@@ -1989,7 +1991,7 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: wallet.address,
           value: ethers.constants.Zero,
           data: wallet.contract.methods.selfExecute(bundle).encodeABI()
@@ -1997,15 +1999,15 @@ contract('MainModule', (accounts: string[]) => {
         {
           delegateCall: false,
           revertOnError: false,
-          gasLimit: ethers.constants.MaxUint256,
+          gasLimit: optimalGasLimit,
           target: callReceiver3.address,
           value: ethers.constants.Zero,
           data: callReceiver3.contract.methods.testCall(51, expected3).encodeABI()
         },
       ]
 
-      await signAndExecuteMetaTx(wallet, owner, transaction, networkId)
-
+      const tx = await signAndExecuteMetaTx(wallet, owner, transaction, networkId)
+  
       expect(await callReceiver1.lastValA()).to.eq.BN(0)
       expect(await callReceiver2.lastValA()).to.eq.BN(0)
       expect(await callReceiver3.lastValA()).to.eq.BN(51)


### PR DESCRIPTION
Depends on #87 

If transaction `gasLimit` equals `0` the sub-call is performed by forwarding all `gasleft()`, no minimum or maximum applied.

This feature may be useful in two scenarios:

a) `gasleft()` behavior changes, and the current `min/max` logic breaks in such a way that users can't make transactions. (I am not sure if that's a possibility, but there are ongoing talks about modifying how internal gas behaves).
b) Nested transaction bundles require complex calculations of `gasLimits`, with this change a single `gasLimit` can be specified on `selfExecute`, that being shared between all sub-calls.
